### PR TITLE
[REFACTOR] 회원가입에서 이미지를 업로드하지 않을 시에 기본 이미지 반환

### DIFF
--- a/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
@@ -59,7 +59,11 @@ public class MemberService {
             member.setLmpDate(null);
         }
 
-        member.getInterests().addAll(categories);
+        if (categories != null && !categories.isEmpty()) {
+            member.getInterests().addAll(categories);
+        }
+        ensureDefaultImage(member);
+
         memberRepository.save(member);
     }
 
@@ -83,6 +87,12 @@ public class MemberService {
         deleteIfCustomImage(member.getImgUrl());
         member.setImgUrl(publicUrl);
         memberRepository.save(member);
+    }
+
+    private void ensureDefaultImage(Member member) {
+        if (member.getImgUrl() == null || member.getImgUrl().isBlank()) {
+            member.setImgUrl(DEFAULT_PROFILE_IMG_URL);
+        }
     }
 
     //기본 이미지로
@@ -127,7 +137,7 @@ public class MemberService {
             }
         }
 
-
+        ensureDefaultImage(member);
 
         memberRepository.save(member);
     }


### PR DESCRIPTION
## 📌 작업 목적

회원가입 등록 시 사용자가 이미지를 업로드하지 않았다면 기본 프로필 이미지를 저장·반환하도록 합니다.

---

## 🗂 작업 유형
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 리팩터링 (Refactor)
- [ ] 성능 개선 (Performance)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포/환경 설정 (Chore)
- [ ] 문서 수정 (Docs)

---

## 🔨 주요 작업 내용

### 기본 이미지 강제 메서드 추가

- MemberService.ensureDefaultImage(Member member) 신설
- imgUrl이 null/blank이면 DEFAULT_PROFILE_IMG_URL로 세팅

### 프로필 등록/수정 시 기본 이미지 보장
- updateProfile 및 editProfile 말미에 ensureDefaultImage(member) 호출

---

## 🧪 테스트 결과

### 이미지 업로드하지 않은 회원 조회
<img width="221" height="228" alt="image" src="https://github.com/user-attachments/assets/612f71af-8963-4a09-bad4-746fa371e086" />


---

## 📎 관련 이슈
- Closes #164 

---

## ✅ 체크리스트
- [x] API 명세서(Swagger/Redoc)가 최신화되었습니다 (해당 시)
- [x] 관련 이슈와 커밋이 명확히 연결되어 있습니다  
